### PR TITLE
Add top_n parameter to encode_tags function

### DIFF
--- a/notebooks/functions_variables.py
+++ b/notebooks/functions_variables.py
@@ -2,7 +2,7 @@ import json
 import pandas as pd
 
 
-def encode_tags(df):
+def encode_tags(df, top_n=10):
     """Use this function to manually encode tags from each sale.
     You could also provide another argument to filter out low
     counts of tags to keep cardinality to a minimum.
@@ -13,9 +13,17 @@ def encode_tags(df):
     Returns:
         pandas.DataFrame: modified with encoded tags
     """
-    tags = df["tags"].tolist()
-    # create a unique list of tags and then create a new column for each tag
-
+    # Count the frequency of each tag
+    counts = df['tags'].explode().value_counts()
+    # Keep top_n tags
+    keep = counts.index[:top_n].tolist()
+    # Filter tags column
+    df['tags'] = df['tags'].apply(
+        lambda x: [t for t in x if t in keep] if isinstance(x, list) else x
+    )
+    exploded_df = df['tags'].explode('tags')
+    dummies = pd.get_dummies(exploded_df, columns=['tags'], prefix='tag')
+    df = pd.concat([dummies, df], axis=1)
     return df
 
 
@@ -23,7 +31,7 @@ def json_to_df(file_path: str):
     with open(file_path, 'r') as f:
         data = json.load(f)
     # Convert JSON data to a DataFrame
-    return pd.json_normalize(data['data']['results'])
+    return pd.json_normalize(data['data']['results'], sep='_')
 
 
 def threshold_column(df, column, threshold=1):


### PR DESCRIPTION
This commit modifies the encode_tags function to include a top_n parameter, allowing users to specify the number of top tags to keep. The function now filters tags based on their frequency, ensuring that only the most common tags are encoded. This change improves the usability and flexibility of the function for different datasets.